### PR TITLE
Show bare label for an incipient link/footnote while streaming

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -22,7 +22,7 @@ kotlin.code.style=official
 systemProp.org.gradle.internal.publish.checksums.insecure=true
 
 GROUP=com.halilibo.compose-richtext
-VERSION_NAME=0.21.0
+VERSION_NAME=0.21.1
 
 POM_DESCRIPTION=A collection of Compose libraries for advanced text formatting and alternative display types.
 

--- a/richtext-commonmark/src/jvmAndroidMain/kotlin/com/halilibo/richtext/commonmark/AstNodeConvert.kt
+++ b/richtext-commonmark/src/jvmAndroidMain/kotlin/com/halilibo/richtext/commonmark/AstNodeConvert.kt
@@ -469,6 +469,36 @@ private fun nextLineStart(content: String, from: Int): Int {
 private fun stripIncompleteLinks(sb: StringBuilder) {
   val text = sb.toString()
 
+  // Case 0: `[label]` with nothing after the `]` yet — an incipient link or
+  // footnote whose `(url)` (or nothing) hasn't streamed in. It's undecidable at
+  // this instant whether a link is coming, so render the bare label and let the
+  // brackets/link "appear" when it resolves (plain -> [1] / plain -> link). That
+  // additive transition reads better than showing `[label]` and then stripping
+  // the brackets away. Only applies while `]` is the final char; once anything
+  // follows it the construct has settled (a space rules out a link; a `(` is
+  // handled by Case 1 below).
+  if (text.endsWith("]")) {
+    var depth = 0
+    var j = text.length - 1
+    while (j >= 0) {
+      when (text[j]) {
+        ']' -> depth++
+        '[' -> {
+          depth--
+          if (depth == 0) {
+            val isImage = j > 0 && text[j - 1] == '!'
+            val removeFrom = if (isImage) j - 1 else j
+            val label = text.substring(j + 1, text.length - 1)
+            sb.delete(removeFrom, sb.length)
+            sb.append(label)
+            return
+          }
+        }
+      }
+      j--
+    }
+  }
+
   // Case 1: `[text](url` — bracket is closed but paren is not.
   // Find the last `](` and check if it has a matching `)`.
   val lastBracketParen = text.lastIndexOf("](")

--- a/richtext-commonmark/src/jvmAndroidTest/kotlin/com/halilibo/richtext/commonmark/AstNodeConvertKtTest.kt
+++ b/richtext-commonmark/src/jvmAndroidTest/kotlin/com/halilibo/richtext/commonmark/AstNodeConvertKtTest.kt
@@ -242,6 +242,29 @@ internal class AstNodeConvertKtTest {
   }
 
   @Test
+  fun `sanitizer strips a trailing closed bracket to its label`() {
+    // Incipient link/footnote: ] is the final char, (url) not arrived yet.
+    val input = "See [the docs]"
+    val result = sanitizePartialMarkdown(input)
+    assertEquals("See the docs", result)
+  }
+
+  @Test
+  fun `sanitizer strips a trailing closed image bracket to its alt`() {
+    val input = "Here ![diagram]"
+    val result = sanitizePartialMarkdown(input)
+    assertEquals("Here diagram", result)
+  }
+
+  @Test
+  fun `sanitizer keeps a closed bracket once content follows it`() {
+    // No longer trailing → settled; leave it (brackets/link appear, not vanish).
+    val input = "See [the docs] now"
+    val result = sanitizePartialMarkdown(input)
+    assertEquals("See [the docs] now", result)
+  }
+
+  @Test
   fun `sanitizer preserves complete image links`() {
     val input = "See ![alt](https://example.com/img.png) here"
     val result = sanitizePartialMarkdown(input)


### PR DESCRIPTION
When rendering partial/streaming markdown, a closed `[label]` with nothing after the `]` yet is undecidable — it may become a `[label](url)` link, or stay literal like a footnote `[1]`. This renders the bare label during streaming and lets the brackets/link **appear** once it resolves (`plain → link`, `plain → [1]`), instead of showing `[label]` then stripping the brackets away — the additive transition reads better.

Only applies while `]` is the final character; once anything follows it, the construct has settled (a space rules out a link; a `(` is handled by the existing incomplete-paren case).

Bumps `VERSION_NAME` to `0.21.1`. Adds unit tests.